### PR TITLE
Feature/integrate external recipe db

### DIFF
--- a/Backend/Tests/Unit-Tests/sendRecipeOfTheDay.test.js
+++ b/Backend/Tests/Unit-Tests/sendRecipeOfTheDay.test.js
@@ -1,6 +1,6 @@
 const { sendRecipeOfTheDay } = require("../../src/Controllers/recipeController");
 
-jest.mock("../../src/Services/recipeService", () => ({
+jest.mock("../../src/Services/recipeOfTheDayService", () => ({
     getRecipeOfTheDay: jest.fn(),
 }));
 

--- a/Backend/Tests/Unit-Tests/sendRecipeOfTheDay.test.js
+++ b/Backend/Tests/Unit-Tests/sendRecipeOfTheDay.test.js
@@ -4,7 +4,7 @@ jest.mock("../../src/Services/recipeService", () => ({
     getRecipeOfTheDay: jest.fn(),
 }));
 
-const { getRecipeOfTheDay } = require("../../src/Services/recipeService");
+const { getRecipeOfTheDay } = require("../../src/Services/recipeOfTheDayService");
 
 describe("sendRecipeOfTheDay (Unit-Test)", () => {
     let req, res;

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -8,6 +8,7 @@
         "joi": "^18.0.1"
       },
       "devDependencies": {
+        "axios": "^1.12.2",
         "express": "^5.1.0",
         "jest": "^30.2.0"
       }
@@ -1573,6 +1574,25 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -2032,6 +2052,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2145,6 +2178,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2271,6 +2314,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2491,6 +2550,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2506,6 +2586,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -2699,6 +2819,22 @@
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4238,6 +4374,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "7.0.1",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "axios": "^1.12.2",
     "express": "^5.1.0",
     "jest": "^30.2.0"
   },

--- a/Backend/src/Controllers/recipeController.js
+++ b/Backend/src/Controllers/recipeController.js
@@ -1,5 +1,5 @@
 const { getRecipeList } = require("../Services/recipeService");
-const { getRecipeOfTheDay } = require("../Services/recipeService");
+const { getRecipeOfTheDay } = require("../Services/recipeOfTheDayService");
 
 async function sendRecipeList(req, res) {
     try {

--- a/Backend/src/Model/recipe.model.js
+++ b/Backend/src/Model/recipe.model.js
@@ -26,7 +26,7 @@ const recipe = Joi.object({
     measure: Joi.array()
         .items(
             Joi.string()
-            .min(2)
+            .min(1)
         ).min(1)
         .max(20)
         .required()

--- a/Backend/src/Model/recipe.model.js
+++ b/Backend/src/Model/recipe.model.js
@@ -10,7 +10,6 @@ const recipe = Joi.object({
         .required(),
 
     instructions: Joi.string()
-        .alphanum()
         .required(),
 
     thumbnail: Joi.string()

--- a/Backend/src/Model/recipe.model.js
+++ b/Backend/src/Model/recipe.model.js
@@ -1,6 +1,6 @@
 const Joi = require('joi');
 
-const recipe = Joi.object({
+const recipeModel = Joi.object({
     id: Joi.string()
         .alphanum()
         .pattern(new RegExp('^[0-9]{5}$'))
@@ -32,4 +32,4 @@ const recipe = Joi.object({
         .required()
 });
 
-module.exports = { recipe }
+module.exports = { recipeModel }

--- a/Backend/src/Model/recipe.model.js
+++ b/Backend/src/Model/recipe.model.js
@@ -9,7 +9,7 @@ const recipe = Joi.object({
     mealName: Joi.string()
         .required(),
 
-    instraction: Joi.string()
+    instructions: Joi.string()
         .alphanum()
         .required(),
 

--- a/Backend/src/Model/recipe.model.js
+++ b/Backend/src/Model/recipe.model.js
@@ -7,7 +7,6 @@ const recipe = Joi.object({
         .required(),
 
     mealName: Joi.string()
-        .alphanum()
         .required(),
 
     instraction: Joi.string()

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -5,7 +5,7 @@ const { recipeSchema } = require("../models/recipe.schema.js");
 let recipeOfTheDayCache = {
     data: null,
     lastUpdated: null
-  };
+};
 
 async function fetchRandomRecipe() {
     const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -19,3 +19,21 @@ let recipeOfTheDayCache = {
     
   return value;
 }
+
+export async function getRecipeOfTheDay() {
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  
+    if (
+      recipeOfTheDayCache.data &&
+      Date.now() - recipeOfTheDayCache.lastUpdated < ONE_DAY_MS
+    ) {
+      return recipeOfTheDayCache.data;
+    }
+  
+    const recipe = await fetchRandomRecipe();
+    recipeOfTheDayCache = {
+      data: recipe,
+      lastUpdated: Date.now()
+    };
+    return recipe;
+  }

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -30,7 +30,7 @@ async function fetchRandomRecipe() {
     }
 }
 
-export async function getRecipeOfTheDay() {
+async function getRecipeOfTheDay() {
     const ONE_DAY_MS = 24 * 60 * 60 * 1000;
   
     if (
@@ -48,7 +48,7 @@ export async function getRecipeOfTheDay() {
     return recipe;
 }
 
-export async function initRecipeScheduler() {
+async function initRecipeScheduler() {
     try {
         console.log("Fetching initial 'Recipe of the Day'...");
         recipeOfTheDayCache.data = await fetchRandomRecipe();
@@ -71,4 +71,4 @@ export async function initRecipeScheduler() {
     }, 24 * 60 * 60 * 1000);
 }
 
-module.exports = { initRecipeScheduler }
+module.exports = { initRecipeScheduler , getRecipeOfTheDay}

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -47,3 +47,26 @@ export async function getRecipeOfTheDay() {
     };
     return recipe;
 }
+
+export async function initRecipeScheduler() {
+    try {
+        console.log("Fetching initial 'Recipe of the Day'...");
+        recipeOfTheDayCache.data = await fetchRandomRecipe();
+        recipeOfTheDayCache.lastUpdated = Date.now();
+        console.log("Recipe of the Day cached successfully.");
+    } catch (err) {
+        console.error("Failed to fetch Recipe of the Day:", err.message);
+    }
+  
+    setInterval(async () => {
+        try {
+            console.log("Refreshing Recipe of the Day...");
+            const newRecipe = await fetchRandomRecipe();
+            recipeOfTheDayCache.data = newRecipe;
+            recipeOfTheDayCache.lastUpdated = Date.now();
+            console.log("Recipe of the Day updated.");
+        } catch (err) {
+            console.error("Scheduled fetch failed:", err.message);
+        }
+    }, 24 * 60 * 60 * 1000);
+}

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -13,7 +13,7 @@ async function fetchRandomRecipe() {
         const rawRecipe = data.meals[0];
         const mapped = mapMealDbRecipe(rawRecipe);
   
-        const { error, value } = recipeSchema.validate(mapped);
+        const { error, value } = recipe.validate(mapped);
         if (error) {
             throw new Error(`Invalid recipe data: ${error.message}`);
         }

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -7,7 +7,7 @@ let recipeOfTheDayCache = {
     lastUpdated: null
   };
 
-  async function fetchRandomRecipe() {
+async function fetchRandomRecipe() {
     const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
     const rawRecipe = data.meals[0];
     const mapped = mapMealDbRecipe(rawRecipe);

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -1,0 +1,3 @@
+const axios = require("axios");
+const { mapMealDbRecipe } = require("../models/recipe.mapper.js");
+const { recipeSchema } = require("../models/recipe.schema.js");

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -1,3 +1,8 @@
 const axios = require("axios");
 const { mapMealDbRecipe } = require("../models/recipe.mapper.js");
 const { recipeSchema } = require("../models/recipe.schema.js");
+
+let recipeOfTheDayCache = {
+    data: null,
+    lastUpdated: null
+  };

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
-const { mapMealDbRecipe } = require("../models/recipe.mapper.js");
-const { recipeSchema } = require("../models/recipe.schema.js");
+const { mapMealDbRecipe } = require("../Model/recipe.mapper.js");
+const { recipe } = require("../Model/recipe.model.js");
 
 let recipeOfTheDayCache = {
     data: null,

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -34,16 +34,16 @@ export async function getRecipeOfTheDay() {
     const ONE_DAY_MS = 24 * 60 * 60 * 1000;
   
     if (
-      recipeOfTheDayCache.data &&
-      Date.now() - recipeOfTheDayCache.lastUpdated < ONE_DAY_MS
+        recipeOfTheDayCache.data &&
+        Date.now() - recipeOfTheDayCache.lastUpdated < ONE_DAY_MS
     ) {
-      return recipeOfTheDayCache.data;
+        return recipeOfTheDayCache.data;
     }
   
     const recipe = await fetchRandomRecipe();
-    recipeOfTheDayCache = {
-      data: recipe,
-      lastUpdated: Date.now()
+        recipeOfTheDayCache = {
+        data: recipe,
+        lastUpdated: Date.now()
     };
     return recipe;
 }

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -36,4 +36,4 @@ export async function getRecipeOfTheDay() {
       lastUpdated: Date.now()
     };
     return recipe;
-  }
+}

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -12,7 +12,7 @@ async function fetchRandomRecipe() {
         const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
         const rawRecipe = data.meals[0];
         const mapped = mapMealDbRecipe(rawRecipe);
-        console.log(mapped)
+
         const { error, value } = recipe.validate(mapped);
         if (error) {
             throw new Error(`Invalid recipe data: ${error.message}`);

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -70,3 +70,5 @@ export async function initRecipeScheduler() {
         }
     }, 24 * 60 * 60 * 1000);
 }
+
+module.exports = { initRecipeScheduler }

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -8,16 +8,26 @@ let recipeOfTheDayCache = {
 };
 
 async function fetchRandomRecipe() {
-    const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
-    const rawRecipe = data.meals[0];
-    const mapped = mapMealDbRecipe(rawRecipe);
+    try {
+        const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
+        const rawRecipe = data.meals[0];
+        const mapped = mapMealDbRecipe(rawRecipe);
   
-    const { error, value } = recipeSchema.validate(mapped);
-    if (error) {
-      throw new Error(`Invalid recipe data: ${error.message}`);
+        const { error, value } = recipeSchema.validate(mapped);
+        if (error) {
+            throw new Error(`Invalid recipe data: ${error.message}`);
+        }
+  
+        return value;
+    } catch (err) {
+        if (err.response) {
+            throw new Error(`API request failed: ${err.response.status} ${err.response.statusText}`);
+        } else if (err.request) {
+            throw new Error("DB error");
+        } else {
+            throw new Error(`Request setup failed: ${err.message}`);
+        }
     }
-    
-  return value;
 }
 
 export async function getRecipeOfTheDay() {

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -12,7 +12,7 @@ async function fetchRandomRecipe() {
         const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
         const rawRecipe = data.meals[0];
         const mapped = mapMealDbRecipe(rawRecipe);
-  
+        console.log(mapped);
         const { error, value } = recipe.validate(mapped);
         if (error) {
             throw new Error(`Invalid recipe data: ${error.message}`);

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -6,3 +6,17 @@ let recipeOfTheDayCache = {
     data: null,
     lastUpdated: null
   };
+
+  async function fetchRandomRecipe() {
+    const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
+    const rawRecipe = data.meals[0];
+    const mapped = mapMealDbRecipe(rawRecipe);
+  
+    // Validate
+    const { error, value } = recipeSchema.validate(mapped);
+    if (error) {
+      throw new Error(`Invalid recipe data: ${error.message}`);
+    }
+    
+  return value;
+}

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -12,7 +12,7 @@ async function fetchRandomRecipe() {
         const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/random.php");
         const rawRecipe = data.meals[0];
         const mapped = mapMealDbRecipe(rawRecipe);
-        console.log(mapped);
+        console.log(mapped)
         const { error, value } = recipe.validate(mapped);
         if (error) {
             throw new Error(`Invalid recipe data: ${error.message}`);

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const { mapMealDbRecipe } = require("../Model/recipe.mapper.js");
-const { recipe } = require("../Model/recipe.model.js");
+const { recipeModel } = require("../Model/recipe.model.js");
 
 let recipeOfTheDayCache = {
     data: null,
@@ -13,7 +13,7 @@ async function fetchRandomRecipe() {
         const rawRecipe = data.meals[0];
         const mapped = mapMealDbRecipe(rawRecipe);
 
-        const { error, value } = recipe.validate(mapped);
+        const { error, value } = recipeModel.validate(mapped);
         if (error) {
             throw new Error(`Invalid recipe data: ${error.message}`);
         }

--- a/Backend/src/Services/recipeOfTheDayService.js
+++ b/Backend/src/Services/recipeOfTheDayService.js
@@ -12,7 +12,6 @@ let recipeOfTheDayCache = {
     const rawRecipe = data.meals[0];
     const mapped = mapMealDbRecipe(rawRecipe);
   
-    // Validate
     const { error, value } = recipeSchema.validate(mapped);
     if (error) {
       throw new Error(`Invalid recipe data: ${error.message}`);

--- a/Backend/src/Services/recipeService.js
+++ b/Backend/src/Services/recipeService.js
@@ -2,4 +2,4 @@ function getRecipeList() {
     throw new Error("DB error");
 }
 
-module.exports = { getRecipeOfTheDay, getRecipeList }
+module.exports = { getRecipeList }

--- a/Backend/src/Services/recipeService.js
+++ b/Backend/src/Services/recipeService.js
@@ -1,11 +1,32 @@
 const axios = require("axios");
+const { mapMealDbRecipe } = require("../Model/recipe.mapper.js");
+const { recipeModel } = require("../Model/recipe.model.js");
 
 async function getRecipeList(keyword) {
     const recipeList = [];
-    
-    const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/search.php?s=" + keyword);
-    
-    //throw new Error("DB error");
+    try{
+        const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/search.php?s=" + keyword);
+        data.meals.forEach((recipe) => {
+            const mapped = mapMealDbRecipe(recipe);
+
+            const { error, value } = recipeModel.validate(mapped);
+            if (!error) {
+                recipeList.push(value);
+            }else {
+                throw new Error(`Invalid recipe data: ${error.message}`);
+            }
+        });
+
+        return {recipe: recipeList}
+    } catch (err) {
+        if (err.response) {
+            throw new Error(`API request failed: ${err.response.status} ${err.response.statusText}`);
+        } else if (err.request) {
+            throw new Error("DB error");
+        } else {
+            throw new Error(`Request setup failed: ${err.message}`);
+        }
+    }
 }
 
 module.exports = { getRecipeList }

--- a/Backend/src/Services/recipeService.js
+++ b/Backend/src/Services/recipeService.js
@@ -1,7 +1,3 @@
-function getRecipeOfTheDay() {
-    throw new Error("DB error");
-}
-
 function getRecipeList() {
     throw new Error("DB error");
 }

--- a/Backend/src/Services/recipeService.js
+++ b/Backend/src/Services/recipeService.js
@@ -1,5 +1,11 @@
-function getRecipeList() {
-    throw new Error("DB error");
+const axios = require("axios");
+
+async function getRecipeList(keyword) {
+    const recipeList = [];
+    
+    const { data } = await axios.get("https://www.themealdb.com/api/json/v1/1/search.php?s=" + keyword);
+    
+    //throw new Error("DB error");
 }
 
 module.exports = { getRecipeList }

--- a/Backend/src/app.js
+++ b/Backend/src/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = require("./Routers");
-cost { intitRecipeScheduler } = require("Service/recipeOfTheDayService");
+const { intitRecipeScheduler } = require("Services/recipeOfTheDayService");
 
 const app = express();
 app.use(express.json());

--- a/Backend/src/app.js
+++ b/Backend/src/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = require("./Routers");
-const { initRecipeScheduler } = require("Services/recipeOfTheDayService");
+const { initRecipeScheduler } = require("./Services/recipeOfTheDayService");
 
 const app = express();
 app.use(express.json());

--- a/Backend/src/app.js
+++ b/Backend/src/app.js
@@ -4,7 +4,7 @@ const { initRecipeScheduler } = require("./Services/recipeOfTheDayService");
 
 const app = express();
 app.use(express.json());
-app.use("/api", router);
+app.use("/api/v1", router);
 
 initRecipeScheduler();
 

--- a/Backend/src/app.js
+++ b/Backend/src/app.js
@@ -5,4 +5,6 @@ const app = express();
 app.use(express.json());
 app.use("/api", router);
 
+initRecipeScheduler();
+
 module.exports = app;

--- a/Backend/src/app.js
+++ b/Backend/src/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = require("./Routers");
-const { intitRecipeScheduler } = require("Services/recipeOfTheDayService");
+const { initRecipeScheduler } = require("Services/recipeOfTheDayService");
 
 const app = express();
 app.use(express.json());

--- a/Backend/src/app.js
+++ b/Backend/src/app.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = require("./Routers");
+cost { intitRecipeScheduler } = require("Service/recipeOfTheDayService");
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
# Summary
Implement integration with **TheMealDB** API.

# Changes
- Added `getRecipeOfTheDay` to fetch a random recipe at server startup.  
- The "recipe of the day" is cached for 24 hours before being refreshed automatically.  
- The `/recipes` endpoint now supports keyword queries and returns a list of matching recipes when available.

# Testing
- Verified that all endpoints return correct data when accessed locally via `localhost:<port>`.

# Related Issue
Closes #6